### PR TITLE
Add new coding standard templates

### DIFF
--- a/templates/api-design.mdc
+++ b/templates/api-design.mdc
@@ -1,0 +1,42 @@
+---
+description: Guide for designing clean and versioned APIs.
+globs: ["**/*.{ts,js,py,go,java,rb}"]
+alwaysApply: false
+---
+---
+name: ApiDesignGuidelines
+type: Auto Attached
+description: Define standards for REST and GraphQL API design and documentation
+glob: **/*.{ts,js,py,go,java,rb}
+priority: high
+---
+
+# API Design Guidelines
+
+Build services with clear contracts and predictable behavior.
+
+## Principles
+
+- Use nouns for resource names and consistent HTTP verbs.
+- Version APIs from the start (`/v1/`).
+- Provide helpful error responses with codes and messages.
+
+## Documentation
+
+- Document each endpoint with examples and parameters.
+- Keep changelog entries for breaking changes.
+- Use OpenAPI or GraphQL schema definitions.
+
+## Security and Performance
+
+- Validate all input data before processing.
+- Support pagination and filtering for collections.
+- Avoid leaking internal implementation details.
+
+## Example
+
+```http
+GET /v1/users?limit=20&page=2
+```
+
+Follow these guidelines to create stable and maintainable APIs.

--- a/templates/component-standards.mdc
+++ b/templates/component-standards.mdc
@@ -1,0 +1,54 @@
+---
+description: Guidelines for building maintainable frontend components.
+globs: ["**/*.{jsx,tsx,vue,svelte}"]
+alwaysApply: false
+---
+---
+name: ComponentStandards
+type: Auto Attached
+description: Enforce structure, naming, and styling rules for UI components across frameworks
+glob: **/*.{jsx,tsx,vue,svelte}
+priority: high
+---
+
+# Component Development Standards
+
+Follow these conventions for all components.
+
+## Naming and Organization
+
+- Use PascalCase for component names.
+- Keep each component in its own folder with `index` export.
+- Group related style files alongside the component.
+
+## Reusability Principles
+
+- Keep components small and focused on a single responsibility.
+- Accept props with explicit types and default values.
+- Avoid side effects in rendering logic.
+
+## Styling Guidelines
+
+- Prefer CSS-in-JS or scoped styles to avoid global leakage.
+- Keep class names predictable and use BEM when applicable.
+- Co-locate styles with components.
+
+## Example
+
+```tsx
+// Example React functional component
+export interface ButtonProps {
+  label: string;
+  onClick?: () => void;
+}
+
+export function Button({ label, onClick }: ButtonProps) {
+  return (
+    <button className="btn" onClick={onClick}>
+      {label}
+    </button>
+  );
+}
+```
+
+This template ensures consistency and reusability across your component library.

--- a/templates/db-best-practices.mdc
+++ b/templates/db-best-practices.mdc
@@ -1,0 +1,43 @@
+---
+description: Database query and schema best practices.
+globs: ["**/*.{sql,ts,js,py}"]
+alwaysApply: false
+---
+---
+name: DatabaseBestPractices
+type: Auto Attached
+description: Optimize database interactions and enforce safe query patterns
+glob: **/*.{sql,ts,js,py}
+priority: high
+---
+
+# Database Best Practices
+
+Use these patterns for all database related code.
+
+## Query Guidelines
+
+- Prefer parameterized queries to avoid SQL injection.
+- Keep queries readable and well-formatted.
+- Use indexes to optimize frequent lookups.
+
+## Schema Management
+
+- Define migrations for all schema changes.
+- Keep naming consistent for tables and columns.
+- Document relationships with foreign keys.
+
+## Transactions and Error Handling
+
+- Wrap related changes in transactions.
+- Handle database errors gracefully and log details.
+- Avoid long running transactions that can lock tables.
+
+## Example
+
+```sql
+-- Parameterized query example
+SELECT * FROM users WHERE id = $1;
+```
+
+Following these rules keeps data access secure and maintainable.

--- a/templates/devops-ci-cd.mdc
+++ b/templates/devops-ci-cd.mdc
@@ -1,0 +1,47 @@
+---
+description: Practices for continuous integration and deployment.
+globs: ["**/.github/workflows/*", "**/*.{yml,yaml}"]
+alwaysApply: false
+---
+---
+name: DevOpsCiCdStandards
+type: Auto Attached
+description: Standardize build, test, and deployment pipelines
+glob: **/*.{yml,yaml}
+priority: high
+---
+
+# DevOps CI/CD Standards
+
+Automate testing and deployment for all projects.
+
+## Pipeline Basics
+
+- Run linting and tests on every commit.
+- Use caching to speed up builds.
+- Fail fast when steps exit with an error.
+
+## Deployment
+
+- Use environment specific configuration files.
+- Tag releases and maintain changelogs.
+- Roll back automatically on failed deployments.
+
+## Security and Monitoring
+
+- Store secrets in a secure vault.
+- Scan dependencies for vulnerabilities.
+- Monitor pipelines for unusual activity.
+
+```yaml
+# Example GitHub Actions snippet
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm ci
+      - run: npm test
+```
+
+These rules help maintain stable and observable delivery pipelines.

--- a/templates/mobile-standards.mdc
+++ b/templates/mobile-standards.mdc
@@ -1,0 +1,46 @@
+---
+description: Rules for mobile application development.
+globs: ["**/*.{swift,kt,dart,js,tsx}"]
+alwaysApply: false
+---
+---
+name: MobileDevelopmentStandards
+type: Auto Attached
+description: Ensure quality and performance across iOS and Android apps
+glob: **/*.{swift,kt,dart,js,tsx}
+priority: high
+---
+
+# Mobile Development Standards
+
+Apply these practices when building mobile apps.
+
+## Architecture
+
+- Separate business logic from UI components.
+- Use dependency injection for testability.
+- Keep navigation flows well defined.
+
+## Performance
+
+- Minimize rendering work on the main thread.
+- Dispose of listeners and subscriptions properly.
+- Use profiling tools to detect bottlenecks.
+
+## UX Considerations
+
+- Support accessibility features like screen readers.
+- Optimize for different screen sizes and orientations.
+- Keep touch targets large and consistent.
+
+```swift
+// Swift example snippet
+struct ContentView: View {
+  var body: some View {
+    Text("Hello, world!")
+      .padding()
+  }
+}
+```
+
+Consistent standards lead to reliable and user-friendly mobile apps.

--- a/templates/testing-strategy.mdc
+++ b/templates/testing-strategy.mdc
@@ -1,0 +1,48 @@
+---
+description: Unified approach for unit, integration, and e2e tests.
+globs: ["**/*.{ts,js,tsx,jsx,py,go,java}"]
+alwaysApply: false
+---
+---
+name: TestingStrategy
+type: Auto Attached
+description: Encourage consistent testing methodology across the project
+glob: **/*.{ts,js,tsx,jsx,py,go,java}
+priority: high
+---
+
+# Testing Strategy
+
+Implement thorough testing at multiple levels.
+
+## Test Pyramid
+
+- **Unit tests** validate small pieces of logic in isolation.
+- **Integration tests** cover interactions between modules.
+- **End-to-end tests** ensure user flows work correctly.
+
+## General Practices
+
+- Write tests alongside new features.
+- Use descriptive test names explaining the expected behavior.
+- Keep tests deterministic and independent.
+
+## Mocking and Fixtures
+
+- Stub external services to keep tests fast.
+- Use fixture data for repeatability.
+
+## Example
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { sum } from './math';
+
+describe('sum', () => {
+  it('adds numbers', () => {
+    expect(sum(1, 2)).toBe(3);
+  });
+});
+```
+
+Consistent testing leads to confident and maintainable code.


### PR DESCRIPTION
## Summary
- add component standards template
- add database best practices template
- add testing strategy template
- add API design template
- add mobile standards template
- add DevOps CI/CD template

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*